### PR TITLE
fix a broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ It calculates complexities as the following:
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/cycromatic.
+Bug reports and pull requests are welcome on GitHub at https://github.com/soutaro/cycromatic.


### PR DESCRIPTION
> https://github.com/[USERNAME]/cycromatic.

I would expect to set a default it.
